### PR TITLE
Config JSON Extender -> Extensions

### DIFF
--- a/src/burp/LoginSessionRule.json
+++ b/src/burp/LoginSessionRule.json
@@ -26,7 +26,7 @@
   "named_params": [],
   "restrict_scope_to_named_params": false,
   "tools_scope": [
-    "Extender"
+    "Extensions"
   ],
   "url_scope": "custom"
 }

--- a/src/burp/UseCookiesSessionRule.json
+++ b/src/burp/UseCookiesSessionRule.json
@@ -13,7 +13,7 @@
     "named_params":[],
     "restrict_scope_to_named_params":false,
     "tools_scope":[
-        "Extender"
+        "Extensions"
     ],
     "url_scope":"all",
     "url_scope_advanced_mode":false


### PR DESCRIPTION
At some point, the Burp config has changed, breaking this extension. This change makes it work with recent Burp versions.